### PR TITLE
Fixes bug with non-deterministic order of GET params in urls

### DIFF
--- a/scrapelib/cache.py
+++ b/scrapelib/cache.py
@@ -27,7 +27,7 @@ class CachingSession(requests.Session):
         preventing cache misses due to non-deterministic server-side
         ordering of params in the query string.
         '''
-        parts = urlparse.urlparse(url.lower())
+        parts = urlparse.urlparse(url)
         newquery = sorted(urlparse.parse_qsl(parts.query))
         newquery = urlparse.urlencode(newquery)
         parts = parts._replace(query=newquery)

--- a/scrapelib/cache.py
+++ b/scrapelib/cache.py
@@ -23,9 +23,9 @@ class CachingSession(requests.Session):
         self.cache_write_only = False
 
     def normalize_url(self, url):
-        '''Rewerites the url with GET params ordered alphabetically.
-        Prevents any non-deterministic ordering of params (server-side)
-        in the query string from causing cache misses.
+        '''Rewrites the url with GET params ordered alphabetically,
+        preventing cache misses due to non-deterministic server-side
+        ordering of params in the query string.
         '''
         parts = urlparse.urlparse(url.lower())
         newquery = sorted(urlparse.parse_qsl(parts.query))

--- a/scrapelib/cache.py
+++ b/scrapelib/cache.py
@@ -15,6 +15,11 @@ try:
 except ImportError:
     import urlparse
 
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
+
 
 class CachingSession(requests.Session):
     def __init__(self, cache_storage=None):
@@ -29,7 +34,7 @@ class CachingSession(requests.Session):
         '''
         parts = urlparse.urlparse(url)
         newquery = sorted(urlparse.parse_qsl(parts.query))
-        newquery = urlparse.urlencode(newquery)
+        newquery = urlencode(newquery)
         parts = parts._replace(query=newquery)
         newurl = urlparse.urlunparse(parts)
         return newurl

--- a/scrapelib/cache.py
+++ b/scrapelib/cache.py
@@ -46,7 +46,9 @@ class CachingSession(requests.Session):
         if method != 'get':
             return None
         url = self.normalize_url(url)
-        return requests.Request(url=url).prepare().url
+        params = kwargs.get('params', {})
+        key = requests.Request(url=url, params=params).prepare().url
+        return key
 
     def should_cache_response(self, response):
         """ Check if a given Response object should be cached.

--- a/scrapelib/cache.py
+++ b/scrapelib/cache.py
@@ -45,9 +45,7 @@ class CachingSession(requests.Session):
         if method != 'get':
             return None
         url = self.normalize_url(url)
-        params = kwargs.get('params', {})
-        key = requests.Request(url=url, params=params).prepare().url
-        return key
+        return requests.Request(url=url, params=kwargs.get('params', {})).prepare().url
 
     def should_cache_response(self, response):
         """ Check if a given Response object should be cached.

--- a/scrapelib/cache.py
+++ b/scrapelib/cache.py
@@ -33,7 +33,8 @@ class CachingSession(requests.Session):
         ordering of params in the query string.
         '''
         parts = urlparse.urlparse(url)
-        newquery = sorted(urlparse.parse_qsl(parts.query))
+        oldquery = urlparse.parse_qsl(parts.query)
+        newquery = sorted(oldquery)
         newquery = urlencode(newquery)
         parts = parts._replace(query=newquery)
         newurl = urlparse.urlunparse(parts)

--- a/scrapelib/cache.py
+++ b/scrapelib/cache.py
@@ -30,8 +30,7 @@ class CachingSession(requests.Session):
         parts = urlparse.urlparse(url.lower())
         newquery = sorted(urlparse.parse_qsl(parts.query))
         newquery = urlparse.urlencode(newquery)
-        newpath = urlparse.unquote_plus(parts.path)
-        parts = parts._replace(query=newquery, path=newpath)
+        parts = parts._replace(query=newquery)
         newurl = urlparse.urlunparse(parts)
         return newurl
 

--- a/scrapelib/tests/test_cache.py
+++ b/scrapelib/tests/test_cache.py
@@ -23,6 +23,38 @@ def test_default_key_for_request():
             DUMMY_URL + '?abc=def&foo=bar')
 
 
+def test_key_param_ordering():
+    '''Verifies that two differently ordered but otherwise equivalent
+    query strings recieve the same cache key.
+    '''
+    cs = CachingSession()
+    params1 = '?a=1&b=2&c=3'
+    params2 = '?c=3&a=1&b=2'
+
+    key1 = cs.key_for_request('get', DUMMY_URL + params1)
+    key2 = cs.key_for_request('get', DUMMY_URL + params2)
+    assert key1 == key2
+
+
+def test_key_param_ordering_with_array():
+    '''Verifies that that two differently ordered but otherwise equivalent
+    query strings continaing array parameters result in the same cache key.
+    This should just work, because python's sorted function sorts a list of
+    sequences by their first item, then second, etc.
+    '''
+    cs = CachingSession()
+    params1 = '?a[]=jamesturk&a[]=thomnasty&a[]=tags'
+    params2 = '?a[]=tags&a[]=jamesturk&a[]=thomnasty'
+    params3 = '?a[]=tags&a[]=jamesturk&a[]=thomnasty&intern=cspencer'
+
+    key1 = cs.key_for_request('get', DUMMY_URL + params1)
+    key2 = cs.key_for_request('get', DUMMY_URL + params2)
+    key3 = cs.key_for_request('get', DUMMY_URL + params3)
+    assert key1 == key2
+    assert key1 != key3
+    assert key2 != key3
+
+
 def test_default_should_cache_response():
     cs = CachingSession()
     resp = requests.Response()


### PR DESCRIPTION
Sorry for the dupe--just moving this one into its own branch so it's not combined with the gzip PR. 

"""
Adds a normalize_url function to cache.CachingSession that rewrites the url with GET params ordered alphabetically, preventing cache misses due to non-deterministic server-side ordering of params in the query string.

While spidering a site that contained urls with non-deterministic order of get params, probably generated from a dictionary-like structure, I noticed the unpredictable ordering was causing cache misses because scrapelib computes cache keys based on the url, params included. Sorting alphabetically fixed it in this case.
"""