### PR TITLE
Create SQLite based cache

### DIFF
--- a/docs/cache.rst
+++ b/docs/cache.rst
@@ -3,14 +3,16 @@ cache overview
 
 .. module:: scrapelib.cache
 
-Assign a :class:`MemoryCache` or :class:`FileCache` to the ``cache_storage``
-property of a :class:`scrapelib.Scraper` to cache responses::
+Assign a :class:`MemoryCache`, :class:`FileCache`, or :class:`SQLiteCache` to
+the ``cache_storage`` property of a :class:`scrapelib.Scraper` to cache
+responses::
 
     from scrapelib import Scraper
     from scrapelib.cache import FileCache
     cache = FileCache('cache-directory')
     scraper = Scraper()
     scraper.cache_storage = cache
+    scraper.cache_write_only = False
 
 MemoryCache object
 ------------------
@@ -23,5 +25,12 @@ FileCache object
 ----------------
 
 .. autoclass:: FileCache
+    :members:
 
+
+SQLiteCache object
+------------------
+
+.. autoclass:: SQLiteCache
+    :members:
 

--- a/scrapelib/cache.py
+++ b/scrapelib/cache.py
@@ -190,7 +190,13 @@ class FileCache(object):
 
 
 class SQLiteCache(object):
-    """SQLite cache to save responses."""
+    """SQLite cache for request responses.
+
+    :param cache_path: path for SQLite database file
+    :param check_last_modified: set to True to compare last-modified
+        timestamp in cached response with value from HEAD request
+
+    """
     _columns = ['key', 'status', 'modified', 'encoding', 'data', 'headers']
 
     def __init__(self, cache_path, check_last_modified=False):
@@ -207,7 +213,7 @@ class SQLiteCache(object):
                  encoding text, data blob, headers blob)""")
 
     def set(self, key, response):
-        """Set cache value for key to response."""
+        """Set cache entry for key with contents of response."""
         mod = response.headers.pop('last-modified', None)
         status = int(response.status_code)
         rec = (key, status, mod, response.encoding, response.content,
@@ -217,6 +223,7 @@ class SQLiteCache(object):
             self._conn.execute("INSERT INTO cache VALUES (?,?,?,?,?,?)", rec)
 
     def get(self, key):
+        """Get cache entry for key, or return None."""
         query = self._conn.execute("SELECT * FROM cache WHERE key=?", (key,))
         rec = query.fetchone()
         if rec is None:

--- a/scrapelib/cache.py
+++ b/scrapelib/cache.py
@@ -9,7 +9,11 @@ import glob
 import hashlib
 import string
 import requests
-
+import sqlite3
+try:
+    import json
+except:
+    import simplejson as json
 
 class CachingSession(requests.Session):
     def __init__(self, cache_storage=None):
@@ -145,7 +149,7 @@ class FileCache(object):
             # TODO: resp.request = request
             return resp
         except IOError:
-            return None
+            return None 
 
     def set(self, key, response):
         key = self._clean_key(key)
@@ -171,3 +175,64 @@ class FileCache(object):
         cache_glob = '*,' + ('[0-9a-f]' * 32)
         for fname in glob.glob(os.path.join(self.cache_dir, cache_glob)):
             os.remove(fname)
+
+
+class SQLiteCache(object):
+    """SQLite cache to save responses."""
+    _columns = ['key', 'status', 'modified', 'encoding', 'data', 'headers']
+
+    def __init__(self, cache_path, check_last_modified=False):
+        self.cache_path = cache_path
+        self.check_last_modified = check_last_modified
+        self._conn = sqlite3.connect(cache_path)
+        self._conn.text_factory = str
+        self._build_table()
+
+    def _build_table(self):
+        """Create table for storing request information and response."""
+        self._conn.execute("""CREATE TABLE IF NOT EXISTS cache
+                (key text UNIQUE, status integer, modified text,
+                 encoding text, data blob, headers blob)""")
+
+    def set(self, key, response):
+        """Set cache value for key to response."""
+        mod = response.headers.pop('last-modified', None)
+        status = int(response.status_code)
+        rec = (key, status, mod, response.encoding, response.content,
+                json.dumps(dict(response.headers)))
+        with self._conn:
+            self._conn.execute("DELETE FROM cache WHERE key=?", (key, ))
+            self._conn.execute("INSERT INTO cache VALUES (?,?,?,?,?,?)", rec)
+
+    def get(self, key):
+        query = self._conn.execute("SELECT * FROM cache WHERE key=?", (key,))
+        rec = query.fetchone()
+        if rec is None:
+            return None
+        rec = dict(zip(self._columns, rec))
+
+        if self.check_last_modified:
+            if rec['modified'] is None:
+                return None  # no last modified header present, so redownload
+
+            head_resp = requests.head(key)
+            new_lm = head_resp.headers.get('last-modified', None)
+            if rec['modified'] != new_lm:
+                return None
+
+        resp = requests.Response()
+        resp._content = rec['data']
+        resp.status_code = rec['status']
+        resp.encoding = rec['encoding']
+        resp.headers = json.loads(rec['headers'])
+        resp.url = key
+        return resp
+
+    def clear(self):
+        """Remove all records from cache."""
+        with self._conn:
+            _ = self._conn.execute('DELETE FROM cache')
+
+    def __del__(self):
+        self._conn.close()
+

--- a/scrapelib/tests/test_cache.py
+++ b/scrapelib/tests/test_cache.py
@@ -1,7 +1,7 @@
 import sys
 
 import requests
-from ..cache import CachingSession, MemoryCache, FileCache
+from ..cache import CachingSession, MemoryCache, FileCache, SQLiteCache
 
 DUMMY_URL = 'http://dummy/'
 HTTPBIN = 'http://httpbin.org/'
@@ -111,3 +111,10 @@ def test_file_cache():
     fc.clear()
     _test_cache_storage(fc)
     fc.clear()
+
+
+def test_sqlite_cache():
+    sc = SQLiteCache('cache.db')
+    sc.clear()
+    _test_cache_storage(sc)
+    sc.clear()


### PR DESCRIPTION
Create SQLite based cache that stores responses to a SQLite database file on disk.  I don't know if this interests you, but it passes existing tests.  I haven't used it for a large scraping project yet.

Here are some possible benefits:
* SQLite [might be faster than files](https://sqlite.org/intern-v-extern-blob.html) in some circumstances.
* Easy to move a cache across computers, or from development machine to server/cluster.
* Use SQL statements to calculate statistics about pages you have scraped or search page content.
* Could be expanded in the future to keep older versions of the same url.  The cache would never delete or replace content when `set` is called.  Instead, it would timestamp the content, then always fetch the latest version when `get` is called.

Here are some possible drawbacks:
* Corruption of the file could ruin the entire cache.
* Some operating systems and volumes might have file size limits that are easily reached using this method. Most modern systems, however, support huge files and SQLite itself supports huge databases.
* Harder to view cached pages in your browser.